### PR TITLE
Correccion error al retornar del determine respuesta rol asistente

### DIFF
--- a/src/services/openai/index.ts
+++ b/src/services/openai/index.ts
@@ -50,7 +50,7 @@ const runDetermine = async (history: ChatCompletionMessageParam[]): Promise<stri
         frequency_penalty: 0,
         presence_penalty: 0,
     });
-    return response.choices[0].message.content
+    return response.choices.length > 0 && response.choices[0].message.role === 'user' ? response.choices[0].message.content : 'unknown'
 }
 
 export { run, runDetermine }


### PR DESCRIPTION
Chatgpt retorna un mensaje como asistente y cuando se consulta desde el flujo lo determina como si se hubiera seleccionado un producto. Por eso solo retornar el mensaje cuando el rol sea 'user'